### PR TITLE
Changed stack version variable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ mkdir -p $CACHE_DIR
 
 # Versions.
 PYTHON_VERSION="python-3.4.2"
-PYTHON_STACK="cedar"
+PYTHON_STACK="cedar-14"
 NGINX_VERSION="nginx-1.7.2"
 PCRE_VERSION='pcre-8.36'
 source $BIN_DIR/utils


### PR DESCRIPTION
As of January 13, 2015 (according to [heroku cedar article](https://devcenter.heroku.com/articles/cedar)) cedar-14 is the new default stack. However, with the variable `stack` set in the `bin/compile` set to "cedar" the compile fails with an SSL error during ensurepip. This fixes it with no (as of yet) detrimental effects that I can tell.