### PR TITLE
Env var behaviour for cache removal.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,10 @@ CACHE_DIR=$2
 CACHED_DIRS=".heroku"
 WORKING_DIR=$(pwd)
 
-#rm -fr $CACHE_DIR
+# If PLATFORM is undefined or defined as HEROKU then remove cache directory.
+if [[ -z ${PLATFORM+HEROKU} == "HEROKU" ]]; then
+    rm -fr $CACHE_DIR
+fi
 mkdir -p $CACHE_DIR
 
 # Versions.

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ CACHED_DIRS=".heroku"
 WORKING_DIR=$(pwd)
 
 # If PLATFORM is undefined or defined as HEROKU then remove cache directory.
-if [[ -z ${PLATFORM+HEROKU} == "HEROKU" ]]; then
+if [[ "${PLATFORM:-HEROKU}" == "HEROKU" ]]; then
     rm -fr $CACHE_DIR
 fi
 mkdir -p $CACHE_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ CACHE_DIR=$2
 CACHED_DIRS=".heroku"
 WORKING_DIR=$(pwd)
 
-rm -fr $CACHE_DIR
+#rm -fr $CACHE_DIR
 mkdir -p $CACHE_DIR
 
 # Versions.
@@ -101,4 +101,3 @@ fi
 
 cp $ROOT_DIR/conf/mime.types $BUILD_DIR/
 cp $BIN_DIR/launch-nginx "$BUILD_DIR/local/sbin"
-


### PR DESCRIPTION
This fixes #6 and introduces a new environment variable "PLATFORM" which when defined and set to "DOKKU" would force the buildback not to perform the cache deletion command.
Otherwise if the env variable is not set, or set to "HEROKU" then that command will be performed.

For Dokku users it means adding an additional export statement in their .env file.

Example contents of .env file:

    # Can be either DOKKU or any other string different from HEROKU.
    export PLATFORM="DOKKU"
    export BUILDPACK_URL=https://github.com/born2discover/heroku-buildpack-pelican